### PR TITLE
Set theme jekyll-theme-minimal

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,6 @@ markdown: kramdown
 # Sass style
 sass:
   style: compressed
+
+# Site theme
+theme: jekyll-theme-minimal


### PR DESCRIPTION
This does the trick with github pages. It is the simplest responsive theme out there.
![image](https://cloud.githubusercontent.com/assets/313750/24733303/4f022c96-1a4d-11e7-961e-f84142e33ed5.png)
