### PR TITLE
Added Prasos & BitPay

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Company|Category|ANN.|
 [CoinGate](https://coingate.com) | Payment Processor | [proof](https://blog.coingate.com/2017/04/coingate-supports-segwit-and-uasf/)
 [Stampery Inc.](https://stampery.com) || [proof](https://twitter.com/StamperyCo/status/852097157951873025)
 [Coinomi](https://coinomi.com/) | Multi-currency Wallet | [proof](https://twitter.com/CoinomiWallet/status/852130791362637825)
-
+[Prasos](https://prasos.fi) | Bitcoin broker | [proof](https://twitter.com/prasosltd/status/852104011767566336)
+[BitPay](https://bitpay.com) | Payment processor | [proof](https://cointelegraph.com/news/bitpay-ceo-supports-user-activated-soft-fork-hints-at-off-chain-expansion)
 
 *[Add your business here by creating a pull request (must include public announcement link)](https://github.com/OPUASF/UASF/pulls)*
 


### PR DESCRIPTION
"BitPay CEO Stephen Pair has added to the company’s stance on the Bitcoin scaling issue, stating support for a user-activated soft fork (UASF).
Speaking in an episode of Let’s Talk Bitcoin! on the weekend, Pair said it was “up to users” to decide the future of the Bitcoin network.
“The most important thing, I think, are the users; I really like the idea of a user-activated soft fork followed by a miner activation,” he told host Adam B. Levine along with Andreas Antonopoulos who was also present."