### PR TITLE
Fix markdown problem for binaries link table

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Operating system | Signatures
 [i686-pc-linux-gnu.tar.gz](binaries/bitcoin-0.14.1-bip148_segwit0.3-i686-pc-linux-gnu.tar.gz) | [Signatures](https://github.com/UASF/gitian.sigs/tree/master/0.14.1-uasfsegwit0.3-linux)
 [aarch64-linux-gnu.tar.gz](binaries/bitcoin-0.14.1-bip148_segwit0.3-aarch64-linux-gnu.tar.gz) | [Signatures](https://github.com/UASF/gitian.sigs/tree/master/0.14.1-uasfsegwit0.3-linux)
 [arm-linux-gnueabihf.tar.gz](binaries/bitcoin-0.14.1-bip148_segwit0.3-arm-linux-gnueabihf.tar.gz) | [Signatures](https://github.com/UASF/gitian.sigs/tree/master/0.14.1-uasfsegwit0.3-linux)
-[Source Code](binaries/bitcoin-0.14.1-bip148_segwit0.3.tar.gz)
+[Source Code](binaries/bitcoin-0.14.1-bip148_segwit0.3.tar.gz) | 
 
 
 ### What is BIP8?


### PR DESCRIPTION
I just saw that github is handling the markdown tables a bit different, compared to my local markdown preview and the table is broken now on the uasf.co website.

I've added a fix which corrects this, sorry for not checking it before making the previous PR.