### PR TITLE
Add section about the UASF slack groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ make install # optional
 
 Finished - you can run now your UASF BIP148 node.
 
+### Are there any groups which I can join?
+
+Yes. There are two slack channels on [slack.bitcoincore.org](http://slack.bitcoincore.org/):
+
+* #UASF for general talk
+* #UASF-SUPPORT for people who want to setup their BIP148 node
+
+Feel free to join, we are always happy about people which are interested and would like to discuss with us!
+
 ### Can BIP148 be cancelled?
 
 Yes. In the event that the economic majority does not support BIP148, users should remove software that enforces BIP148. A flag day activation for SegWit would be the next logical steps and require coordination of the community, most likely towards the end of 2018.


### PR DESCRIPTION
I've added a small section with a hint to the UASF slack groups at slack.bitcoincore.org.