### PR TITLE
point directly to 0.14.1 version before core has released 0.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ _N.B. This will not enforce UASF on your node; it will only signal that you supp
 
 ### How can I compile BIP148 myself or download signed binaries?
 
-Signed binaries can be downloaded [here](https://github.com/UASF/bitcoin/releases). To build from source, follow the instructions below.
+Signed binaries can be downloaded [here](https://github.com/UASF/bitcoin/releases/tag/v0.14.1-uasfsegwit0.3). To build from source, follow the instructions below.
 
 First, install all necessary dependencies which are mentioned in the official Bitcoin build instructions:
 


### PR DESCRIPTION
To avoid confusion and to avoid people installing something based on core that is not already released by core