### PR TITLE
Adding BitOfertas.com support and proof 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Company|Category|Support Type|ANN.|
  [Coinkite](http://coinkite.com) | Hardware/Software | Support| [proof](https://twitter.com/coinkite/status/851822761794260992)
  [Coinomi](https://coinomi.com/) | Multi-currency Wallet | Support| [proof](https://twitter.com/CoinomiWallet/status/852130791362637825)
  [Freedom Node](https://freedomnode.com/) | Education | Support| [proof](https://freedomnode.com/bitcoin-core-support.txt)
+ [InPay](https://inpay.pl/) | Payment Processor | Support| [proof](https://twitter.com/InPayTo/status/868093985004421120)
  [JoinMarket](https://github.com/JoinMarket-Org/joinmarket) | Mixer | Support| [proof](https://twitter.com/joinmarket/status/851177740900368385)
  [Microsoft](http://microsoft.com)| Decentralized Identity dpt.|Support|[proof](https://twitter.com/csuwildcat/status/851832163792150528)
  [Prasos](https://prasos.fi) | Bitcoin broker | Support | [proof](https://twitter.com/prasosltd/status/852104011767566336)


### PR DESCRIPTION
[BitOfertas](https://www.bitofertas.com) | Exchange | Support | [proof](https://pastebin.com/raw/Ms9DUKz4)