### PR TITLE
Adding link to beta web wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Company|Category|Support Type|ANN.|
  [Stampery Inc.](https://stampery.com) | Timestamping| Support |[proof](https://twitter.com/StamperyCo/status/852097157951873025)
  [Simple Bitcoin Wallet](https://btcontract.com/) | Wallet| Support |[proof](https://btcontract.com/#trusted-node)
  [Trezor](https://trezor.io/) | Hardware Wallet | Ready | [proof](https://twitter.com/slushcz/status/851502735736418304)
+ [Trezor Web Wallet](https://wallet.trezor.io/) | Hardware Wallet | Ready, in beta | [proof](https://twitter.com/slushcz/status/882241787062087680), [implemented](https://beta-wallet.trezor.io)
  [Vaultoro](https://www.vaultoro.com) | Bitcoin & gold exchange | Support | [proof](https://twitter.com/Vaultoro/status/851370469018284034)
  [Walltime](https://walltime.info/) | Exchange | Support |[proof](https://pastebin.com/raw/FeNHqySX)
  [Yogh](http://yogh.io) | Explorer| Support |[proof](http://srv1.yogh.io/#json:getnetworkinfo)


### PR DESCRIPTION
I have added a separate row, since Trezor hardware wallet itself doesn't care about UASF.